### PR TITLE
Darker names and disable name colors

### DIFF
--- a/src/elements/message.js
+++ b/src/elements/message.js
@@ -7,20 +7,19 @@ const shortlink = require('../util/shortlink');
 const Storage = require('../Storage');
 
 async function messageElement(message, mdy = false) {
+  const ctx = require('../index.js');
   const color = (...x) => {
-    if (message.member) {
-      let hex = message.member.displayHexColor;
-      if (hex === '#000000') hex = '#FFFFFF';
-      const c = hexToRgb(hex);
-      return colors.fg.getRgb(c.r, c.g, c.b) + x.join(' ') + colors.reset;
-    } else {
-      return colors.fg.getRgb(5, 5, 5) + x.join(' ') + colors.reset;
+    const defaultHex = ctx.rc.dark === 'true' ? '#423e3e' : '#FFFFFF';
+    let hex = defaultHex;
+    if (message.member && ctx.rc.color !== 'false' && message.member.displayHexColor !== '#000000') {
+      hex = message.member.displayHexColor;
     }
+    const c = hexToRgb(hex);
+    return colors.fg.getRgb(c.r, c.g, c.b) + x.join(' ') + colors.reset;
   };
   const time = `{yellow-fg}${timestamp(message.createdAt, mdy)}{/yellow-fg}`;
   switch (message.type) {
     case 'DEFAULT': {
-      const ctx = require('../index.js');
       if (message.client.user.blocked.has(message.author.id)) {
         if (ctx.rc.blocked === 'true') return;
         return `${time} 1 Blocked message`;


### PR DESCRIPTION
Basically lets you have darker names and lets you disable name colors (= set to the default one, in this case if you choose to have darker then you have darker if not you have the normal white). With "darker" I mean only for the default color. I chose some gray because I felt like it combined with a fully white background. Feel free to tell me if I should set it to some other color.

The options are `dark` for darker names (set to `true` to enable) and `color` for disabling colors (set to `false` to disable them).

_(And no, not 99% of terminals are dark; Mac comes with white background by default for example)_